### PR TITLE
changing the key values

### DIFF
--- a/src/covid_updater/scraping/countries/france.py
+++ b/src/covid_updater/scraping/countries/france.py
@@ -33,7 +33,7 @@ class FranceScraper(IncrementalScraper):
                 "reg": "region",
                 "jour": "date",
                 "n_tot_dose1": "people_vaccinated",
-                "n_tot_dose2": "people_fully_vaccinated",
+                "n_tot_complet": "people_fully_vaccinated",
             },
         )
 


### PR DESCRIPTION
the variable names in the source are changed as per [26 April](https://www.data.gouv.fr/fr/datasets/donnees-relatives-aux-personnes-vaccinees-contre-la-covid-19-1).

Currently in the repo the data is till 24 April and the website is providing data for 26 April, data for 25th April is missing. I tried looking for it, but was not able to find any older datasets on the website. If you are free you can look into it !