### PR TITLE
Update vaccination data endpoint for Finland

### DIFF
--- a/src/covid_updater/scraping/countries/finland.py
+++ b/src/covid_updater/scraping/countries/finland.py
@@ -9,7 +9,7 @@ class FinlandScraper(Scraper):
         super().__init__(
             country="Finland",
             country_iso="FI",
-            data_url="https://piikki-api.lab.juiciness.io/administrations",
+            data_url="https://piikki-api.lab.juiciness.io/administrations/areas",
             data_url_reference="https://piikki.juiciness.io/",
             region_renaming={
                 "Åland": "Aland",


### PR DESCRIPTION
The old one does not work anymore, so here's the updated URI.